### PR TITLE
Updated Wizards

### DIFF
--- a/lift_advanced_bs3/src/main/webapp/assets/css/app-bs-theme.css
+++ b/lift_advanced_bs3/src/main/webapp/assets/css/app-bs-theme.css
@@ -232,3 +232,7 @@ a.list-group-item:hover, a.list-group-item:focus {
     font-weight: normal;
 }
 
+.fieldContainer .label {
+  color: inherit;
+}
+

--- a/lift_advanced_bs3/src/main/webapp/templates-hidden/wizard-all.html
+++ b/lift_advanced_bs3/src/main/webapp/templates-hidden/wizard-all.html
@@ -1,57 +1,56 @@
 <div>
-  <wizard:screen_info><div>Page <wizard:screen_number></wizard:screen_number> of <wizard:total_screens></wizard:total_screens></div></wizard:screen_info>
-  <wizard:wizard_top> <div> <wizard:bind></wizard:bind> </div> </wizard:wizard_top>
-  <wizard:screen_top> <div> <wizard:bind></wizard:bind> </div> </wizard:screen_top>
-  <wizard:errors> <div> <ul> <wizard:item> <li> <wizard:bind></wizard:bind> </li> </wizard:item> </ul> </div> </wizard:errors>
-  <div>
-    <wizard:fields>
-      <table>
-	<tbody>
-            <tr lift:bind="wizard:line">
-              <td>
-		<wizard:label>
-		  <label wizard:for="">
-		    <wizard:bind></wizard:bind>
-		  </label>
-		</wizard:label>
-		<wizard:help>
-		  <span>
-		    <wizard:bind></wizard:bind>
-		  </span>
-		</wizard:help>
-		<wizard:field_errors>
-		  <ul>
-		    <wizard:error>
-		      <li>
-			<wizard:bind></wizard:bind>
-		      </li>
-		    </wizard:error> 
-		  </ul>
-		</wizard:field_errors>
-              </td>
-              <td>
-		<wizard:form></wizard:form>
-	      </td>
-            </tr>
-	</tbody>
-      </table>
-    </wizard:fields>
+  <div class="screenInfo">
+    Page <span class="screenNumber">-1</span> of <span class="totalScreens">-1423123<span>
   </div>
+
+  <div class="wizardTop">
+    top content for whole wizard
+  </div>
+
+  <div class="screenTop">
+    top content for screen
+  </div>
+
+  <div class="globalErrors">
+    <ul>
+      <li class="error">global error</li>
+    </ul>
+  </div>
+
+  <div class="fields">
+    <table>
+      <tbody>
+        <tr class="fieldContainer">
+          <td>
+            <label class="label field">field label</label>
+            <span class="help">field help</span>
+            <ul class="errors">
+              <li class="error">field error</li>
+            </ul>
+          </td>
+          <td>
+            <span class="value fieldValue">current field value</span>
+          </td>
+        </tr>
+        </tbody>
+    </table>
+  </div>
+
   <div>
     <table>
-      <tr> 
-	<td>
-	  <wizard:prev></wizard:prev> 
-	</td>
-	<td>
-	  <wizard:cancel></wizard:cancel>
-	</td>
-	<td>
-	  <wizard:next></wizard:next>
-	</td>
+      <tr>
+        <td><button class="prev">previous</button></td>
+        <td><button class="cancel">cancel</button></td>
+        <td><button class="next">next</button></td>
       </tr>
     </table>
   </div>
-  <wizard:screen_bottom> <div> <wizard:bind></wizard:bind> </div> </wizard:screen_bottom>
-  <wizard:wizard_bottom> <div> <wizard:bind></wizard:bind> </div> </wizard:wizard_bottom>
+
+  <div class="screenBottom">
+    bottom content for screen
+  </div>
+
+  <div class="wizardBottom">
+    bottom content for whole wizard
+  </div>
 </div>

--- a/lift_basic/src/main/webapp/templates-hidden/wizard-all.html
+++ b/lift_basic/src/main/webapp/templates-hidden/wizard-all.html
@@ -1,57 +1,56 @@
 <div>
-  <wizard:screen_info><div>Page <wizard:screen_number></wizard:screen_number> of <wizard:total_screens></wizard:total_screens></div></wizard:screen_info>
-  <wizard:wizard_top> <div> <wizard:bind></wizard:bind> </div> </wizard:wizard_top>
-  <wizard:screen_top> <div> <wizard:bind></wizard:bind> </div> </wizard:screen_top>
-  <wizard:errors> <div> <ul> <wizard:item> <li> <wizard:bind></wizard:bind> </li> </wizard:item> </ul> </div> </wizard:errors>
-  <div>
-    <wizard:fields>
-      <table>
-	<tbody>
-            <tr lift:bind="wizard:line">
-              <td>
-		<wizard:label>
-		  <label wizard:for="">
-		    <wizard:bind></wizard:bind>
-		  </label>
-		</wizard:label>
-		<wizard:help>
-		  <span>
-		    <wizard:bind></wizard:bind>
-		  </span>
-		</wizard:help>
-		<wizard:field_errors>
-		  <ul>
-		    <wizard:error>
-		      <li>
-			<wizard:bind></wizard:bind>
-		      </li>
-		    </wizard:error> 
-		  </ul>
-		</wizard:field_errors>
-              </td>
-              <td>
-		<wizard:form></wizard:form>
-	      </td>
-            </tr>
-	</tbody>
-      </table>
-    </wizard:fields>
+  <div class="screenInfo">
+    Page <span class="screenNumber">-1</span> of <span class="totalScreens">-1423123<span>
   </div>
+
+  <div class="wizardTop">
+    top content for whole wizard
+  </div>
+
+  <div class="screenTop">
+    top content for screen
+  </div>
+
+  <div class="globalErrors">
+    <ul>
+      <li class="error">global error</li>
+    </ul>
+  </div>
+
+  <div class="fields">
+    <table>
+      <tbody>
+        <tr class="fieldContainer">
+          <td>
+            <label class="label field">field label</label>
+            <span class="help">field help</span>
+            <ul class="errors">
+              <li class="error">field error</li>
+            </ul>
+          </td>
+          <td>
+            <span class="value fieldValue">current field value</span>
+          </td>
+        </tr>
+        </tbody>
+    </table>
+  </div>
+
   <div>
     <table>
-      <tr> 
-	<td>
-	  <wizard:prev></wizard:prev> 
-	</td>
-	<td>
-	  <wizard:cancel></wizard:cancel>
-	</td>
-	<td>
-	  <wizard:next></wizard:next>
-	</td>
+      <tr>
+        <td><button class="prev">previous</button></td>
+        <td><button class="cancel">cancel</button></td>
+        <td><button class="next">next</button></td>
       </tr>
     </table>
   </div>
-  <wizard:screen_bottom> <div> <wizard:bind></wizard:bind> </div> </wizard:screen_bottom>
-  <wizard:wizard_bottom> <div> <wizard:bind></wizard:bind> </div> </wizard:wizard_bottom>
+
+  <div class="screenBottom">
+    bottom content for screen
+  </div>
+
+  <div class="wizardBottom">
+    bottom content for whole wizard
+  </div>
 </div>

--- a/lift_blank/src/main/webapp/templates-hidden/wizard-all.html
+++ b/lift_blank/src/main/webapp/templates-hidden/wizard-all.html
@@ -1,57 +1,56 @@
 <div>
-  <wizard:screen_info><div>Page <wizard:screen_number></wizard:screen_number> of <wizard:total_screens></wizard:total_screens></div></wizard:screen_info>
-  <wizard:wizard_top> <div> <wizard:bind></wizard:bind> </div> </wizard:wizard_top>
-  <wizard:screen_top> <div> <wizard:bind></wizard:bind> </div> </wizard:screen_top>
-  <wizard:errors> <div> <ul> <wizard:item> <li> <wizard:bind></wizard:bind> </li> </wizard:item> </ul> </div> </wizard:errors>
-  <div>
-    <wizard:fields>
-      <table>
-	<tbody>
-            <tr lift:bind="wizard:line">
-              <td>
-		<wizard:label>
-		  <label wizard:for="">
-		    <wizard:bind></wizard:bind>
-		  </label>
-		</wizard:label>
-		<wizard:help>
-		  <span>
-		    <wizard:bind></wizard:bind>
-		  </span>
-		</wizard:help>
-		<wizard:field_errors>
-		  <ul>
-		    <wizard:error>
-		      <li>
-			<wizard:bind></wizard:bind>
-		      </li>
-		    </wizard:error> 
-		  </ul>
-		</wizard:field_errors>
-              </td>
-              <td>
-		<wizard:form></wizard:form>
-	      </td>
-            </tr>
-	</tbody>
-      </table>
-    </wizard:fields>
+  <div class="screenInfo">
+    Page <span class="screenNumber">-1</span> of <span class="totalScreens">-1423123<span>
   </div>
+
+  <div class="wizardTop">
+    top content for whole wizard
+  </div>
+
+  <div class="screenTop">
+    top content for screen
+  </div>
+
+  <div class="globalErrors">
+    <ul>
+      <li class="error">global error</li>
+    </ul>
+  </div>
+
+  <div class="fields">
+    <table>
+      <tbody>
+        <tr class="fieldContainer">
+          <td>
+            <label class="label field">field label</label>
+            <span class="help">field help</span>
+            <ul class="errors">
+              <li class="error">field error</li>
+            </ul>
+          </td>
+          <td>
+            <span class="value fieldValue">current field value</span>
+          </td>
+        </tr>
+        </tbody>
+    </table>
+  </div>
+
   <div>
     <table>
-      <tr> 
-	<td>
-	  <wizard:prev></wizard:prev> 
-	</td>
-	<td>
-	  <wizard:cancel></wizard:cancel>
-	</td>
-	<td>
-	  <wizard:next></wizard:next>
-	</td>
+      <tr>
+        <td><button class="prev">previous</button></td>
+        <td><button class="cancel">cancel</button></td>
+        <td><button class="next">next</button></td>
       </tr>
     </table>
   </div>
-  <wizard:screen_bottom> <div> <wizard:bind></wizard:bind> </div> </wizard:screen_bottom>
-  <wizard:wizard_bottom> <div> <wizard:bind></wizard:bind> </div> </wizard:wizard_bottom>
+
+  <div class="screenBottom">
+    bottom content for screen
+  </div>
+
+  <div class="wizardBottom">
+    bottom content for whole wizard
+  </div>
 </div>


### PR DESCRIPTION
Updates the wizard templates to support Lift 3's CSS-based wizard
setup. Also adds a tweak for the bootstrap base project so that labels
in wizards aren't white-text-on-white-background.
