### PR TITLE
Upgrade sbt to 0.13.13

### DIFF
--- a/lift_advanced_bs3/project/build.properties
+++ b/lift_advanced_bs3/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.8
+sbt.version=0.13.13

--- a/lift_advanced_bs3/sbt
+++ b/lift_advanced_bs3/sbt
@@ -21,7 +21,7 @@ if test -f ~/.liftsh.config; then
 fi
 
 # Internal options, always specified
-INTERNAL_OPTS="-Dfile.encoding=UTF-8 -Xmx1768m -noverify -XX:ReservedCodeCacheSize=296m -XX:+CMSClassUnloadingEnabled -XX:+UseConcMarkSweepGC -XX:MaxPermSize=812m"
+INTERNAL_OPTS="-Dfile.encoding=UTF-8 -Xmx1768m -noverify -XX:ReservedCodeCacheSize=296m -XX:+CMSClassUnloadingEnabled -XX:+UseConcMarkSweepGC"
 
 # Add 64bit specific option
 exec java -version 2>&1 | grep -q "64-Bit" && INTERNAL_OPTS="${INTERNAL_OPTS} -XX:+UseCompressedOops -XX:ReservedCodeCacheSize=328m"

--- a/lift_basic/project/build.properties
+++ b/lift_basic/project/build.properties
@@ -1,2 +1,1 @@
-sbt.version=0.13.7
-
+sbt.version=0.13.13

--- a/lift_basic/sbt
+++ b/lift_basic/sbt
@@ -21,7 +21,7 @@ if test -f ~/.liftsh.config; then
 fi
 
 # Internal options, always specified
-INTERNAL_OPTS="-Dfile.encoding=UTF-8 -Xmx1768m -noverify -XX:ReservedCodeCacheSize=296m -XX:+CMSClassUnloadingEnabled -XX:+UseConcMarkSweepGC -XX:MaxPermSize=812m"
+INTERNAL_OPTS="-Dfile.encoding=UTF-8 -Xmx1768m -noverify -XX:ReservedCodeCacheSize=296m -XX:+CMSClassUnloadingEnabled -XX:+UseConcMarkSweepGC"
 
 # Add 64bit specific option
 exec java -version 2>&1 | grep -q "64-Bit" && INTERNAL_OPTS="${INTERNAL_OPTS} -XX:+UseCompressedOops -XX:ReservedCodeCacheSize=328m"

--- a/lift_blank/project/build.properties
+++ b/lift_blank/project/build.properties
@@ -1,2 +1,1 @@
-sbt.version=0.13.7
-
+sbt.version=0.13.13

--- a/lift_blank/sbt
+++ b/lift_blank/sbt
@@ -21,7 +21,7 @@ if test -f ~/.liftsh.config; then
 fi
 
 # Internal options, always specified
-INTERNAL_OPTS="-Dfile.encoding=UTF-8 -Xmx1768m -noverify -XX:ReservedCodeCacheSize=296m -XX:+CMSClassUnloadingEnabled -XX:+UseConcMarkSweepGC -XX:MaxPermSize=812m"
+INTERNAL_OPTS="-Dfile.encoding=UTF-8 -Xmx1768m -noverify -XX:ReservedCodeCacheSize=296m -XX:+CMSClassUnloadingEnabled -XX:+UseConcMarkSweepGC"
 
 # Add 64bit specific option
 exec java -version 2>&1 | grep -q "64-Bit" && INTERNAL_OPTS="${INTERNAL_OPTS} -XX:+UseCompressedOops -XX:ReservedCodeCacheSize=328m"


### PR DESCRIPTION
removed old java ops whcih is not valid for java 8 any more.