### PR TITLE
Readme headings fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,21 @@
 
 Template Applications for Lift 3.0
 =======
-#Lift version 3.0 templates
+
+## Lift version 3.0 templates
 
 This repository contains templates for Lift projects.
 
 These templates offer a starting point for your Lift-based project.
 
-##Getting started.
+### Getting started
 
 Most people will want to start with the `lift_basic` template. This template shows you how to use:
 
 * `Mapper`, which is one way to connect to a database using **Lift**.
 * `specs2`, to write unit tests (or spec tests).
 
-##How to use them.
+### How to use them
 
 At your terminal, enter:
 
@@ -28,7 +29,7 @@ At your terminal, enter:
 5. Your Lift application is now running at [127.0.0.1:8080](http://127.0.0.1:8080)
 
 
-##How to work with Lift.
+### How to work with Lift
 
 Now that you have your first Lift application running, you may want to look around the code, change a few things and see what happens.
 
@@ -44,6 +45,6 @@ You can use any IDE you want, even a text editor, but one of the best IDE for Sc
 
        You can now navigate through the different files, and make changes as you wish. To see those changes take effect, you go back to `sbt` and restart `jetty` by doing `;container:stop;container:start`
 
-## Getting help.     
+### Getting help     
 
 Questions, feedback, etc. please join the conversation at https://groups.google.com/forum/#!forum/liftweb

--- a/README.md
+++ b/README.md
@@ -1,20 +1,20 @@
 
 Template Applications for Lift 3.0
 =======
-#Lift version 3.0 templates
+# Lift version 3.0 templates
 
 This repository contains templates for Lift projects.
 
 These templates offer a starting point for your Lift-based project.
 
-##Getting started.
+## Getting started
 
 Most people will want to start with the `lift_basic` template. This template shows you how to use:
 
 * `Mapper`, which is one way to connect to a database using **Lift**.
 * `specs2`, to write unit tests (or spec tests).
 
-##How to use them.
+## How to use them
 
 At your terminal, enter:
 
@@ -28,7 +28,7 @@ At your terminal, enter:
 5. Your Lift application is now running at [127.0.0.1:8080](http://127.0.0.1:8080)
 
 
-##How to work with Lift.
+## How to work with Lift
 
 Now that you have your first Lift application running, you may want to look around the code, change a few things and see what happens.
 
@@ -44,6 +44,6 @@ You can use any IDE you want, even a text editor, but one of the best IDE for Sc
 
        You can now navigate through the different files, and make changes as you wish. To see those changes take effect, you go back to `sbt` and restart `jetty` by doing `;container:stop;container:start`
 
-## Getting help.     
+## Getting help     
 
 Questions, feedback, etc. please join the conversation at https://groups.google.com/forum/#!forum/liftweb


### PR DESCRIPTION
Fixing markdown headings parsing problem.
It seems like the (github) markdown translation of headings works
better if there is a space between the '#':es and the heading text.