### PR TITLE
Bumping logback version to 1.2.3 for a security vulnerability fix

### DIFF
--- a/lift_advanced_bs3/build.sbt
+++ b/lift_advanced_bs3/build.sbt
@@ -26,7 +26,7 @@ libraryDependencies ++= {
     "org.eclipse.jetty" % "jetty-webapp"        % "8.1.17.v20150415"  % "container,test",
     "org.eclipse.jetty" % "jetty-plus"          % "8.1.17.v20150415"  % "container,test", // For Jetty Config
     "org.eclipse.jetty.orbit" % "javax.servlet" % "3.0.0.v201112011016" % "container,test" artifacts Artifact("javax.servlet", "jar", "jar"),
-    "ch.qos.logback"    % "logback-classic"     % "1.1.3",
+    "ch.qos.logback"    % "logback-classic"     % "1.2.3",
     "org.specs2"        %% "specs2-core"             % "3.8.6"           % "test",
     "com.h2database"    % "h2"                  % "1.4.187"
   )

--- a/lift_basic/build.sbt
+++ b/lift_basic/build.sbt
@@ -26,7 +26,7 @@ libraryDependencies ++= {
     "org.eclipse.jetty" % "jetty-webapp"        % "8.1.17.v20150415"  % "container,test",
     "org.eclipse.jetty" % "jetty-plus"          % "8.1.17.v20150415"  % "container,test", // For Jetty Config
     "org.eclipse.jetty.orbit" % "javax.servlet" % "3.0.0.v201112011016" % "container,test" artifacts Artifact("javax.servlet", "jar", "jar"),
-    "ch.qos.logback"    % "logback-classic"     % "1.1.3",
+    "ch.qos.logback"    % "logback-classic"     % "1.2.3",
     "org.specs2"        %% "specs2-core"        % "3.6.4"           % "test",
     "com.h2database"    % "h2"                  % "1.4.187"
   )

--- a/lift_blank/build.sbt
+++ b/lift_blank/build.sbt
@@ -24,7 +24,7 @@ libraryDependencies ++= {
     "org.eclipse.jetty" % "jetty-webapp"        % "8.1.17.v20150415"  % "container,test",
     "org.eclipse.jetty" % "jetty-plus"          % "8.1.17.v20150415"  % "container,test", // For Jetty Config
     "org.eclipse.jetty.orbit" % "javax.servlet" % "3.0.0.v201112011016" % "container,test" artifacts Artifact("javax.servlet", "jar", "jar"),
-    "ch.qos.logback"    % "logback-classic"     % "1.1.3",
+    "ch.qos.logback"    % "logback-classic"     % "1.2.3",
     "org.specs2"        %% "specs2-core"        % "3.6.4"           % "test"
   )
 }


### PR DESCRIPTION
Each project is now configured to utilize logback `1.2.3` to avoid a known security vulnerability.

Vulnerability details: https://nvd.nist.gov/vuln/detail/CVE-2017-5929
Related play framework security advisory: https://www.playframework.com/security/vulnerability/20170407-LogbackDeser